### PR TITLE
Fix updating preprint from expression

### DIFF
--- a/src/docmap-parser.test.ts
+++ b/src/docmap-parser.test.ts
@@ -363,5 +363,27 @@ describe('docmap-parser', () => {
     });
   });
 
+  it('updates published date from a later step', () => {
+    const parsedData = parseDocMap(fixtures.preprintPublishedDataInLaterSteps());
+
+    expect(parsedData.versions.length).toStrictEqual(1);
+    expect(parsedData.versions[0]).toMatchObject({
+      publishedDate: new Date('2023-06-23'),
+    });
+  });
+
+  it('updates url and content from a later step, but keeps published date from earlier step', () => {
+    const parsedData = parseDocMap(fixtures.preprintUrlAndContentDataInLaterSteps());
+
+    expect(parsedData.versions.length).toStrictEqual(1);
+    expect(parsedData.versions[0].preprint).toMatchObject({
+      publishedDate: new Date('2023-06-23'),
+      url: 'http://somewhere.org/preprint/article1',
+      content: [
+        's3://somewhere-org-storage-bucket/preprint/article1.meca',
+      ],
+    });
+  });
+
   it.todo('finds a revised preprint evaluations, but no new reviews from a docmap');
 });

--- a/src/docmap-parser.ts
+++ b/src/docmap-parser.ts
@@ -120,6 +120,35 @@ const createReviewedPreprintFrom = (expression: Expression): ReviewedPreprint =>
     preprint: newPreprint,
   };
 };
+const updateReviewedPreprintFrom = (reviewedPreprint: ReviewedPreprint, expression: Expression): ReviewedPreprint => {
+  if (isPreprintAboutExpression(reviewedPreprint.preprint, expression)) {
+    const { preprint } = reviewedPreprint;
+
+    if (Array.isArray(expression.content) && expression.content.length > 0) {
+      if (!Array.isArray(preprint.content)) {
+        preprint.content = [];
+      }
+      preprint.content.push(...expression.content.map((contentItem) => contentItem.url).filter((url): url is string => !!url));
+    }
+
+    if (expression.published) {
+      preprint.publishedDate = expression.published;
+    }
+
+    if (expression.url) {
+      preprint.url = expression.url;
+    }
+  }
+
+  if (isPreprintAboutExpression(reviewedPreprint, expression)) {
+    const reviewedPreprintToUpdate = reviewedPreprint;
+    if (expression.published) {
+      reviewedPreprintToUpdate.publishedDate = expression.published;
+    }
+  }
+
+  return reviewedPreprint;
+};
 
 const findPreprintDescribedBy = (expression: Expression, preprintCollection: Array<ReviewedPreprint>):
 ReviewedPreprint | undefined => preprintCollection.find(
@@ -138,7 +167,7 @@ const findAndUpdateOrAddPreprintDescribedBy = (expression: Expression, preprintC
     return addPreprintDescribedBy(expression, preprintCollection);
   }
   // Update fields, default to any data already there.
-  foundPreprint.publishedDate = expression.published ?? foundPreprint.publishedDate;
+  updateReviewedPreprintFrom(foundPreprint, expression);
   return foundPreprint;
 };
 

--- a/src/docmap-parser.ts
+++ b/src/docmap-parser.ts
@@ -88,19 +88,16 @@ const getPreprintFromExpression = (expression: Expression): Preprint => {
   if (!expression.doi) {
     throw Error('Cannot identify Expression by DOI');
   }
-  const content = [];
-  if (Array.isArray(expression.content) && expression.content.length > 0) {
-    content.push(...expression.content.map((contentItem) => contentItem.url).filter((url): url is string => !!url));
-  }
 
+  const content = (Array.isArray(expression.content) && expression.content.length > 0) ? { content: expression.content.map((contentItem) => contentItem.url).filter((url): url is string => !!url) } : {};
   const url = expression.url ? { url: expression.url } : {};
 
   return {
     id: expression.identifier ?? expression.doi,
     doi: expression.doi,
-    content,
     publishedDate: expression.published,
     versionIdentifier: expression.versionIdentifier,
+    ...content,
     ...url,
   };
 };

--- a/src/docmap-parser.ts
+++ b/src/docmap-parser.ts
@@ -146,7 +146,6 @@ const updateReviewedPreprintFrom = (reviewedPreprint: ReviewedPreprint, expressi
       reviewedPreprintToUpdate.publishedDate = expression.published;
     }
   }
-
   return reviewedPreprint;
 };
 

--- a/src/test-fixtures/docmapGenerators.ts
+++ b/src/test-fixtures/docmapGenerators.ts
@@ -79,6 +79,46 @@ export const fixtures = {
     return generateDocMap('test', publisher, firstStep);
   },
 
+  preprintPublishedDataInLaterSteps: (): DocMap => {
+    const preprint1 = generatePreprint('preprint/article1');
+    const preprint2 = generatePreprint('preprint/article1', new Date('2023-06-23'));
+    const firstStep = generateStep(
+      [],
+      [generateAction([], [preprint1])],
+      [],
+    );
+    addNextStep(firstStep, generateStep(
+      [],
+      [generateAction([], [preprint2])],
+      [],
+    ));
+
+    return generateDocMap('test', publisher, firstStep);
+  },
+
+  preprintUrlAndContentDataInLaterSteps: (): DocMap => {
+    const preprint1 = generatePreprint('preprint/article1', new Date('2023-06-23'));
+    const preprint2 = generatePreprint(
+      'preprint/article1',
+      undefined,
+      'http://somewhere.org/preprint/article1',
+      undefined,
+      [generateContent(ManifestationType.DigitalManifestation, 's3://somewhere-org-storage-bucket/preprint/article1.meca')],
+    );
+    const firstStep = generateStep(
+      [],
+      [generateAction([], [preprint1])],
+      [],
+    );
+    addNextStep(firstStep, generateStep(
+      [],
+      [generateAction([], [preprint2])],
+      [],
+    ));
+
+    return generateDocMap('test', publisher, firstStep);
+  },
+
   assertPreprintPublishedThenUnderReview: (): DocMap => {
     const preprint = generatePreprint('preprint/article1', new Date('2022-03-01'));
     const firstStep = generateStep(


### PR DESCRIPTION
data-hub api docmaps fail to update content URLs of reviewed preprint parsing. These changes tackle content, url, and published date updating when we find new information