### PR TITLE
fix: Exclude "dist" directory from TypeScript compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
   },
   "exclude": [
     "src/**/*.test.ts",
-    "src/test-fixtures"
+    "src/test-fixtures",
+    "./dist/**/*"
   ]
 }


### PR DESCRIPTION
I was able to recreate this failure in CI locally: https://github.com/elifesciences/docmap-ts/actions/runs/5728132942/job/15522037266

The fix was found here: https://stackoverflow.com/questions/42609768/typescript-error-cannot-write-file-because-it-would-overwrite-input-file