### PR TITLE
Revert "Rename prepublish script to build to avoid autorun on yarn"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
         cache: yarn
         registry-url: 'https://npm.pkg.github.com'
     - run: yarn
-    - run: yarn build
+    - run: yarn prepublish
     - run: yarn publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "fetch-and-test-data-hub-docmap": "ts-node src/fetch-and-parse.ts",
     "test": "jest",
     "lint": "eslint --ext .tsx,.ts src/",
-    "build": "tsc"
+    "prepublish": "tsc"
   },
   "dependencies": {
     "@tsconfig/node18": "^1.0.1",


### PR DESCRIPTION
Reverts elifesciences/docmap-ts#29

This is necessary because we are not yet in a position to use the package until we switch to a registry that allows anonymous access.