### PR TITLE
feat: add support for fetching specific DocMap by manuscript ID

### DIFF
--- a/src/fetch-and-parse.ts
+++ b/src/fetch-and-parse.ts
@@ -3,17 +3,29 @@ import { exit } from 'process';
 import { DocMap } from './docmap';
 import { parsePreprintDocMap } from './docmap-parser';
 
-fetch('https://data-hub-api--stg.elifesciences.org/enhanced-preprints/docmaps/v1/index')
+const msid = process.argv[2] || null;
+const docmapUrl = `https://data-hub-api--stg.elifesciences.org/enhanced-preprints/docmaps/v2/${msid ? `by-publisher/elife/get-by-manuscript-id?manuscript_id=${msid}` : 'index'}`;
+
+const processDocmap = (docMapStruct: DocMap) => {
+  const docMapEditableStruct = JSON.parse(JSON.stringify(docMapStruct));
+  // You can make edits here
+
+  const docMapJson = JSON.stringify(docMapEditableStruct);
+  const parsedDocMap = parsePreprintDocMap(docMapJson);
+  console.log(JSON.stringify(docMapEditableStruct, undefined, '  '));
+  console.log(JSON.stringify(parsedDocMap, undefined, '  '));
+};
+
+fetch(docmapUrl)
   .then((data) => data.json())
   .then((data) => {
-    data.docmaps.forEach((docMapStruct: DocMap) => {
-      const docMapEditableStruct = JSON.parse(JSON.stringify(docMapStruct));
-      // You can make edits here
+    if (msid) {
+      processDocmap(data);
+      exit(1);
+    }
 
-      const docMapJson = JSON.stringify(docMapEditableStruct);
-      const parsedDocMap = parsePreprintDocMap(docMapJson);
-      console.log(JSON.stringify(docMapEditableStruct, undefined, '  '));
-      console.log(JSON.stringify(parsedDocMap, undefined, '  '));
+    data.docmaps.forEach((docMapStruct: DocMap) => {
+      processDocmap(docMapStruct);
       exit(1);
     });
   });


### PR DESCRIPTION
This commit updates the fetch-and-parse method to allow fetching of specific DocMap data by manuscript ID. It also refactors the processing of DocMap data into a separate function for better code organization.