### PR TITLE
feat: add related content to manuscript

### DIFF
--- a/src/docmap-generator.ts
+++ b/src/docmap-generator.ts
@@ -3,6 +3,7 @@ import {
   Assertion,
   AssertionStatus,
   AuthorResponse,
+  Complement,
   DocMap,
   DOI,
   EvaluationSummary,
@@ -123,13 +124,22 @@ export const generateWebContent = (url: Url): WebPage => ({
   url,
 });
 
-export const generateManuscript = (doi?: DOI, identifier?: string, volumeIdentifier?: string, electronicArticleIdentifier?: string, subjectDisciplines?: string[], published?: Date): Manuscript => ({
+export const generateComplement = (type: string, title: string, url: Url, content?: string, imageUrl?: Url) => ({
+  type,
+  title,
+  url,
+  content,
+  imageUrl,
+});
+
+export const generateManuscript = (doi?: DOI, identifier?: string, volumeIdentifier?: string, electronicArticleIdentifier?: string, subjectDisciplines?: string[], complement?: Complement[], published?: Date): Manuscript => ({
   type: 'manuscript',
   doi,
   identifier,
   volumeIdentifier,
   electronicArticleIdentifier,
   subjectDisciplines,
+  complement,
   published,
 });
 

--- a/src/docmap-generator.ts
+++ b/src/docmap-generator.ts
@@ -3,13 +3,13 @@ import {
   Assertion,
   AssertionStatus,
   AuthorResponse,
-  Complement,
   DocMap,
   DOI,
   EvaluationSummary,
   Expression,
   ExpressionType,
   Input,
+  Insight,
   Item,
   JsonLDAddonFrame,
   JsonLDFrameUrl,
@@ -21,7 +21,8 @@ import {
   Participant,
   PeerReview,
   Preprint,
-  Publisher, Reply,
+  Publisher,
+  Reply,
   RevisedPreprint,
   Step,
   UpdateSummary,
@@ -114,6 +115,14 @@ export const generateVersionOfRecord = (published: Date, content: WebPage[], doi
   content,
 });
 
+export const generateInsight = (title: string, url: Url, description?: string, thumbnail?: Url): Insight => ({
+  type: ExpressionType.Insight,
+  title,
+  url,
+  description,
+  thumbnail,
+});
+
 export const generateContent = (type: ManifestationType, url: Url): Manifestation => ({
   type,
   url,
@@ -124,15 +133,7 @@ export const generateWebContent = (url: Url): WebPage => ({
   url,
 });
 
-export const generateComplement = (type: string, title: string, url: Url, content?: string, imageUrl?: Url) => ({
-  type,
-  title,
-  url,
-  content,
-  imageUrl,
-});
-
-export const generateManuscript = (doi?: DOI, identifier?: string, volumeIdentifier?: string, electronicArticleIdentifier?: string, subjectDisciplines?: string[], complement?: Complement[], published?: Date): Manuscript => ({
+export const generateManuscript = (doi?: DOI, identifier?: string, volumeIdentifier?: string, electronicArticleIdentifier?: string, subjectDisciplines?: string[], complement?: Expression[], published?: Date): Manuscript => ({
   type: 'manuscript',
   doi,
   identifier,

--- a/src/docmap-parser.test.ts
+++ b/src/docmap-parser.test.ts
@@ -608,6 +608,17 @@ describe('docmap-parser', () => {
     });
   });
 
+  it('parses relatedContent', () => {
+    const docmap = fixtures.preprintWithPartialManuscriptWithRelatedContent();
+    const parsedData = parseDocMap(docmap);
+
+    expect(parsedData.manuscript?.relatedContent).toEqual([{
+      type: 'insight',
+      title: 'Insight Title',
+      url: 'https://somewhere.org/insight',
+    }]);
+  });
+
   it('parses publishedDate', () => {
     const docmap = fixtures.preprintWithPartialManuscriptWithPublishedDate();
     const parsedData = parseDocMap(docmap);

--- a/src/docmap-parser.ts
+++ b/src/docmap-parser.ts
@@ -82,6 +82,14 @@ type ReviewedPreprint = {
   license?: string,
 };
 
+type RelatedContentItem = {
+  type: string,
+  title: string,
+  url: string,
+  content?: string,
+  imageUrl?: string,
+};
+
 export type VersionedReviewedPreprint = ReviewedPreprint & {
   versionIdentifier: string,
 };
@@ -92,6 +100,7 @@ export type Manuscript = {
   eLocationId?: string,
   publishedDate?: Date,
   subjects?: string[],
+  relatedContent?: RelatedContentItem[],
 };
 
 export type ManuscriptData = {
@@ -110,6 +119,7 @@ const getManuscriptFromExpression = (expression: Expression): Manuscript | false
     volume: expression.partOf.volumeIdentifier,
     eLocationId: expression.partOf.electronicArticleIdentifier,
     subjects: expression.partOf.subjectDisciplines,
+    relatedContent: expression.partOf.complement,
     publishedDate: expression.partOf.published,
   };
 };
@@ -215,6 +225,9 @@ const findAndUpdateOrAddPreprintDescribedBy = (expression: Expression, preprintC
     }
     if (foundManuscriptData.subjects) {
       existingManuscript.subjects = foundManuscriptData.subjects;
+    }
+    if (foundManuscriptData.relatedContent) {
+      existingManuscript.relatedContent = foundManuscriptData.relatedContent;
     }
     if (foundManuscriptData.publishedDate) {
       existingManuscript.publishedDate = foundManuscriptData.publishedDate;

--- a/src/docmap-parser.ts
+++ b/src/docmap-parser.ts
@@ -84,10 +84,10 @@ type ReviewedPreprint = {
 
 type RelatedContentItem = {
   type: string,
-  title: string,
-  url: string,
-  content?: string,
-  imageUrl?: string,
+  title?: string,
+  url?: string,
+  description?: string,
+  thumbnail?: string,
 };
 
 export type VersionedReviewedPreprint = ReviewedPreprint & {

--- a/src/docmap.ts
+++ b/src/docmap.ts
@@ -23,6 +23,7 @@ export enum ExpressionType {
   AuthorResponse = 'author-response',
   Reply = 'reply',
   UpdateSummary = 'update-summary',
+  Insight = 'insight',
 }
 
 export enum ManifestationType {
@@ -81,6 +82,14 @@ export type VersionOfRecord = Expression & {
   type: ExpressionType.VersionOfRecord,
 };
 
+export type Insight = Expression & {
+  type: ExpressionType.Insight,
+  title: string,
+  url: Url,
+  description?: string,
+  thumbnail?: Url,
+};
+
 export type WebPage = Manifestation & {
   type: ManifestationType.WebPage,
 };
@@ -128,14 +137,6 @@ export type Assertion = {
   happened?: Date,
 };
 
-export type Complement = {
-  type: string,
-  title: string,
-  url: Url,
-  description?: string,
-  imageUrl?: Url,
-};
-
 export type Manuscript = {
   type: 'manuscript',
   doi?: DOI,
@@ -143,7 +144,7 @@ export type Manuscript = {
   volumeIdentifier?: string,
   electronicArticleIdentifier?: string,
   subjectDisciplines?: string[],
-  complement?: Complement[],
+  complement?: Expression[],
   published?: Date,
 };
 

--- a/src/docmap.ts
+++ b/src/docmap.ts
@@ -41,6 +41,9 @@ export type Expression = {
   content?: Manifestation[],
   license?: string,
   partOf?: Manuscript,
+  title?: string,
+  description?: string,
+  thumbnail?: Url,
 };
 
 export type Manifestation = {
@@ -84,10 +87,6 @@ export type VersionOfRecord = Expression & {
 
 export type Insight = Expression & {
   type: ExpressionType.Insight,
-  title: string,
-  url: Url,
-  description?: string,
-  thumbnail?: Url,
 };
 
 export type WebPage = Manifestation & {

--- a/src/docmap.ts
+++ b/src/docmap.ts
@@ -128,6 +128,14 @@ export type Assertion = {
   happened?: Date,
 };
 
+export type Complement = {
+  type: string,
+  title: string,
+  url: Url,
+  description?: string,
+  imageUrl?: Url,
+};
+
 export type Manuscript = {
   type: 'manuscript',
   doi?: DOI,
@@ -135,6 +143,7 @@ export type Manuscript = {
   volumeIdentifier?: string,
   electronicArticleIdentifier?: string,
   subjectDisciplines?: string[],
+  complement?: Complement[],
   published?: Date,
 };
 

--- a/src/test-fixtures/docmapGenerators.ts
+++ b/src/test-fixtures/docmapGenerators.ts
@@ -19,6 +19,7 @@ import {
   generateUnderReviewAssertion,
   generateWebContent,
   generateManuscript,
+  generateComplement,
 } from '../docmap-generator';
 
 const publisher = {
@@ -64,8 +65,15 @@ export const fixtures = {
     return generateDocMap('test', publisher, firstStep);
   },
 
+  preprintWithPartialManuscriptWithRelatedContent: (): DocMap => {
+    const manuscript = generateManuscript('10.1101/123456', '123456', undefined, 'RP123456', undefined, [generateComplement('insight', 'Insight Title', 'https://somewhere.org/insight')]);
+    const preprint = generatePreprint('preprint/article1', new Date('2022-03-01'), undefined, undefined, undefined, undefined, manuscript);
+    const firstStep = generateStep([], [generateAction([], [preprint])], []);
+    return generateDocMap('test', publisher, firstStep);
+  },
+
   preprintWithPartialManuscriptWithPublishedDate: (): DocMap => {
-    const manuscript = generateManuscript('10.1101/123456', '123456', undefined, 'RP123456', undefined, new Date('2022-03-01'));
+    const manuscript = generateManuscript('10.1101/123456', '123456', undefined, 'RP123456', undefined, undefined, new Date('2022-03-01'));
     const preprint = generatePreprint('preprint/article1', new Date('2022-03-01'), undefined, undefined, undefined, undefined, manuscript);
     const firstStep = generateStep([], [generateAction([], [preprint])], []);
     return generateDocMap('test', publisher, firstStep);

--- a/src/test-fixtures/docmapGenerators.ts
+++ b/src/test-fixtures/docmapGenerators.ts
@@ -19,7 +19,7 @@ import {
   generateUnderReviewAssertion,
   generateWebContent,
   generateManuscript,
-  generateComplement,
+  generateInsight,
 } from '../docmap-generator';
 
 const publisher = {
@@ -66,7 +66,7 @@ export const fixtures = {
   },
 
   preprintWithPartialManuscriptWithRelatedContent: (): DocMap => {
-    const manuscript = generateManuscript('10.1101/123456', '123456', undefined, 'RP123456', undefined, [generateComplement('insight', 'Insight Title', 'https://somewhere.org/insight')]);
+    const manuscript = generateManuscript('10.1101/123456', '123456', undefined, 'RP123456', undefined, [generateInsight('Insight Title', 'https://somewhere.org/insight')]);
     const preprint = generatePreprint('preprint/article1', new Date('2022-03-01'), undefined, undefined, undefined, undefined, manuscript);
     const firstStep = generateStep([], [generateAction([], [preprint])], []);
     return generateDocMap('test', publisher, firstStep);


### PR DESCRIPTION
This commit includes changes to support adding related content to the manuscript. It introduces a new type 'Complement' and updates the 'generateManuscript' function to include an optional 'complement' parameter. The 'docmap-parser' is updated to parse 'relatedContent' and the tests are updated to cover these changes.