### PR TITLE
Added support for corrected assertions in docmap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elifesciences/docmap-ts",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "author": "Scott Aubrey <scott@aubrey.org.uk>",
   "license": "MIT",
   "repository": {

--- a/src/generators/docmap-generators.ts
+++ b/src/generators/docmap-generators.ts
@@ -209,6 +209,12 @@ export const generatePeerReviewedAssertion = (item: Item, date?: Date): Assertio
   happened: date,
 });
 
+export const generateCorrectedAssertion = (item: Item, date?: Date): Assertion => ({
+  item,
+  status: AssertionStatus.Corrected,
+  happened: date,
+});
+
 export const generateEnhancedAssertion = (item: Item, date?: Date): Assertion => ({
   item,
   status: AssertionStatus.Enhanced,

--- a/src/parser/docmap-parser.test.ts
+++ b/src/parser/docmap-parser.test.ts
@@ -445,6 +445,28 @@ describe('docmap-parser', () => {
     });
   });
 
+  it('can parse a docmap with an inference of version of record corrected from input/outputs', () => {
+    const parsedData = parseDocMap(fixtures.inferredVersionOfRecordCorrected());
+
+    expect(parsedData.versions.length).toStrictEqual(1);
+    expect(parsedData.versions[0]).toMatchObject<VersionedPreprint>({
+      doi: 'vor/article1',
+      id: 'vor/article1',
+      publishedDate: new Date('2024-05-09'),
+      url: 'https://version-of-record',
+      content: [
+        'https://doi.org/version-of-record',
+        'https://doi.org/version-of-record-corrected',
+        'https://doi.org/version-of-record-corrected-again',
+      ],
+      versionIdentifier: '1',
+      correctedDate: [
+        new Date('2024-06-09'),
+        new Date('2024-06-10'),
+      ],
+    });
+  });
+
   it('inference of reviewed preprint from input/outputs', () => {
     const parsedData = parseDocMap(fixtures.inferredReviewedPreprint());
 

--- a/src/parser/docmap-parser.test.ts
+++ b/src/parser/docmap-parser.test.ts
@@ -462,9 +462,15 @@ describe('docmap-parser', () => {
       versionIdentifier: '1',
       corrections: [
         {
+          content: [
+            'https://doi.org/version-of-record-corrected',
+          ],
           correctedDate: new Date('2024-06-09'),
         },
         {
+          content: [
+            'https://doi.org/version-of-record-corrected-again',
+          ],
           correctedDate: new Date('2024-06-10'),
         },
       ],

--- a/src/parser/docmap-parser.test.ts
+++ b/src/parser/docmap-parser.test.ts
@@ -445,8 +445,8 @@ describe('docmap-parser', () => {
     });
   });
 
-  it('can parse a docmap with an inference of version of record corrected from input/outputs', () => {
-    const parsedData = parseDocMap(fixtures.inferredVersionOfRecordCorrected());
+  it('can parse corrections on a published version of record', () => {
+    const parsedData = parseDocMap(fixtures.assertVersionOfRecordPublishedThenCorrected());
 
     expect(parsedData.versions.length).toStrictEqual(1);
     expect(parsedData.versions[0]).toMatchObject<VersionedPreprint>({

--- a/src/parser/docmap-parser.test.ts
+++ b/src/parser/docmap-parser.test.ts
@@ -460,9 +460,13 @@ describe('docmap-parser', () => {
         'https://doi.org/version-of-record-corrected-again',
       ],
       versionIdentifier: '1',
-      correctedDate: [
-        new Date('2024-06-09'),
-        new Date('2024-06-10'),
+      corrections: [
+        {
+          correctedDate: new Date('2024-06-09'),
+        },
+        {
+          correctedDate: new Date('2024-06-10'),
+        },
       ],
     });
   });

--- a/src/parser/docmap-parser.ts
+++ b/src/parser/docmap-parser.ts
@@ -471,7 +471,12 @@ const parseStep = (step: Step, preprints: Array<ReviewedPreprint>, manuscript: M
       }
       const correction = { correctedDate: preprintCorrectedAssertion.happened };
       const versionOfRecord = getPublishedVersionOfRecord(step);
-      const content = (versionOfRecord && versionOfRecord.content ? versionOfRecord.content : []).filter((manifestation) => manifestation.type === 'web-page' && manifestation.url).map((manifestation) => manifestation.url ?? '');
+      const content = (versionOfRecord && versionOfRecord.content ? versionOfRecord.content : []).reduce<string[]>((ac, { type, url }) => {
+        if (type === 'web-page' && url) {
+          ac.push(url);
+        }
+        return ac;
+      }, []);
       preprint.corrections.push({
         ...correction,
         ...(content.length > 0 ? { content } : {}),

--- a/src/parser/docmap-parser.ts
+++ b/src/parser/docmap-parser.ts
@@ -465,10 +465,10 @@ const parseStep = (step: Step, preprints: Array<ReviewedPreprint>, manuscript: M
     // Update preprint with corrections
     const preprint = findAndUpdateOrAddPreprintDescribedBy(preprintCorrectedAssertion.item, preprints, manuscript);
     if (preprintCorrectedAssertion.happened) {
-      if (!Array.isArray(preprint.correctedDate)) {
-        preprint.correctedDate = [];
+      if (!Array.isArray(preprint.corrections)) {
+        preprint.corrections = [];
       }
-      preprint.correctedDate.push(preprintCorrectedAssertion.happened);
+      preprint.corrections.push({ correctedDate: preprintCorrectedAssertion.happened });
     }
   }
 

--- a/src/parser/docmap-parser.ts
+++ b/src/parser/docmap-parser.ts
@@ -462,7 +462,7 @@ const parseStep = (step: Step, preprints: Array<ReviewedPreprint>, manuscript: M
 
   const preprintCorrectedAssertion = step.assertions.find((assertion) => assertion.status === AssertionStatus.Corrected);
   if (preprintCorrectedAssertion) {
-    // Update type and sent for review date
+    // Update preprint with corrections
     const preprint = findAndUpdateOrAddPreprintDescribedBy(preprintCorrectedAssertion.item, preprints, manuscript);
     if (preprintCorrectedAssertion.happened) {
       if (!Array.isArray(preprint.correctedDate)) {

--- a/src/parser/docmap-parser.ts
+++ b/src/parser/docmap-parser.ts
@@ -59,6 +59,10 @@ export enum ContentType {
   AuthorResponse = 'author-response',
 }
 
+type Correction = {
+  correctedDate: Date,
+};
+
 type Preprint = {
   id: string,
   versionIdentifier?: string,
@@ -67,7 +71,7 @@ type Preprint = {
   url?: string,
   content?: string[],
   license?: string,
-  correctedDate?: Date[],
+  corrections?: Correction[],
 };
 
 type ReviewedPreprint = {
@@ -81,7 +85,7 @@ type ReviewedPreprint = {
   reviewedDate?: Date,
   authorResponseDate?: Date,
   license?: string,
-  correctedDate?: Date[],
+  corrections?: Correction[],
 };
 
 type RelatedContentItem = {

--- a/src/parser/docmap-parser.ts
+++ b/src/parser/docmap-parser.ts
@@ -385,6 +385,17 @@ const extractExpressions = (step: Step): ExtractedExpressions => {
   };
 };
 
+const getPublishedOutput = (step: Step): Item | false => {
+  const items = extractExpressions(step);
+  if (items.preprintOutputs.length === 1) {
+    return items.preprintOutputs[0];
+  }
+  if (items.versionOfRecordOutputs.length === 1) {
+    return items.versionOfRecordOutputs[0];
+  }
+  return false;
+};
+
 const getPublishedVersionOfRecord = (step: Step): Item | false => {
   const items = extractExpressions(step);
   return (items.versionOfRecordOutputs.length === 1) ? items.versionOfRecordOutputs[0] : false;
@@ -470,8 +481,8 @@ const parseStep = (step: Step, preprints: Array<ReviewedPreprint>, manuscript: M
         preprint.corrections = [];
       }
       const correction = { correctedDate: preprintCorrectedAssertion.happened };
-      const versionOfRecord = getPublishedVersionOfRecord(step);
-      const content = (versionOfRecord && versionOfRecord.content ? versionOfRecord.content : []).reduce<string[]>((ac, { type, url }) => {
+      const publishedOutput = getPublishedOutput(step);
+      const content = (publishedOutput && publishedOutput.content ? publishedOutput.content : []).reduce<string[]>((ac, { type, url }) => {
         if (type === 'web-page' && url) {
           ac.push(url);
         }

--- a/src/parser/docmap-parser.ts
+++ b/src/parser/docmap-parser.ts
@@ -67,6 +67,7 @@ type Preprint = {
   url?: string,
   content?: string[],
   license?: string,
+  correctedDate?: Date[],
 };
 
 type ReviewedPreprint = {
@@ -80,6 +81,7 @@ type ReviewedPreprint = {
   reviewedDate?: Date,
   authorResponseDate?: Date,
   license?: string,
+  correctedDate?: Date[],
 };
 
 type RelatedContentItem = {
@@ -452,6 +454,18 @@ const parseStep = (step: Step, preprints: Array<ReviewedPreprint>, manuscript: M
     // Update type and sent for review date
     const preprint = findAndUpdateOrAddPreprintDescribedBy(preprintUnderReviewAssertion.item, preprints, manuscript);
     preprint.sentForReviewDate = preprintUnderReviewAssertion.happened;
+  }
+
+  const preprintCorrectedAssertion = step.assertions.find((assertion) => assertion.status === AssertionStatus.Corrected);
+  if (preprintCorrectedAssertion) {
+    // Update type and sent for review date
+    const preprint = findAndUpdateOrAddPreprintDescribedBy(preprintCorrectedAssertion.item, preprints, manuscript);
+    if (preprintCorrectedAssertion.happened) {
+      if (!Array.isArray(preprint.correctedDate)) {
+        preprint.correctedDate = [];
+      }
+      preprint.correctedDate.push(preprintCorrectedAssertion.happened);
+    }
   }
 
   const inferredRepublished = getRepublishedPreprint(step);

--- a/src/parser/docmap-parser.ts
+++ b/src/parser/docmap-parser.ts
@@ -60,6 +60,7 @@ export enum ContentType {
 }
 
 type Correction = {
+  content?: string[],
   correctedDate: Date,
 };
 
@@ -468,7 +469,13 @@ const parseStep = (step: Step, preprints: Array<ReviewedPreprint>, manuscript: M
       if (!Array.isArray(preprint.corrections)) {
         preprint.corrections = [];
       }
-      preprint.corrections.push({ correctedDate: preprintCorrectedAssertion.happened });
+      const correction = { correctedDate: preprintCorrectedAssertion.happened };
+      const versionOfRecord = getPublishedVersionOfRecord(step);
+      const content = (versionOfRecord && versionOfRecord.content ? versionOfRecord.content : []).filter((manifestation) => manifestation.type === 'web-page' && manifestation.url).map((manifestation) => manifestation.url ?? '');
+      preprint.corrections.push({
+        ...correction,
+        ...(content.length > 0 ? { content } : {}),
+      });
     }
   }
 

--- a/src/test-fixtures/docmap-parser.ts
+++ b/src/test-fixtures/docmap-parser.ts
@@ -550,7 +550,7 @@ export const fixtures = {
     return generateDocMap('test', publisher, firstStep);
   },
 
-  inferredVersionOfRecordCorrected: (): DocMap => {
+  assertVersionOfRecordPublishedThenCorrected: (): DocMap => {
     const versionOfRecordOutput = generateVersionOfRecord(new Date('2024-05-09'), [generateWebContent('https://doi.org/version-of-record')], 'vor/article1', 'https://version-of-record');
     const versionOfRecord = {
       type: versionOfRecordOutput.type,

--- a/src/test-fixtures/docmap-parser.ts
+++ b/src/test-fixtures/docmap-parser.ts
@@ -19,7 +19,7 @@ import {
   generateUnderReviewAssertion,
   generateWebContent,
   generateManuscript,
-  generateInsight, generateVersionOfRecord,
+  generateInsight, generateVersionOfRecord, generateCorrectedAssertion,
 } from '../generators/docmap-generators';
 
 const publisher = {
@@ -544,6 +544,56 @@ export const fixtures = {
   inferredVersionOfRecord: (): DocMap => {
     const versionOfRecord = generateVersionOfRecord(new Date('2024-05-09'), [generateWebContent('https://doi.org/version-of-record')], 'vor/article1', 'https://version-of-record');
     const firstStep = generateStep([], [generateAction([], [versionOfRecord])], []);
+
+    return generateDocMap('test', publisher, firstStep);
+  },
+
+  inferredVersionOfRecordCorrected: (): DocMap => {
+    const versionOfRecordOutput = generateVersionOfRecord(new Date('2024-05-09'), [generateWebContent('https://doi.org/version-of-record')], 'vor/article1', 'https://version-of-record');
+    const versionOfRecord = {
+      type: versionOfRecordOutput.type,
+      doi: versionOfRecordOutput.doi,
+      versionIdentifier: versionOfRecordOutput.versionIdentifier,
+    };
+    const firstStep = generateStep([], [generateAction([], [versionOfRecordOutput])], []);
+    const nextStep = addNextStep(firstStep, generateStep(
+      [{
+        ...versionOfRecord,
+        identifier: versionOfRecordOutput.identifier,
+      }],
+      [
+        generateAction([], [
+          {
+            ...versionOfRecord,
+            content: [
+              generateWebContent('https://doi.org/version-of-record-corrected')
+            ],
+          },
+        ]),
+      ],
+      [
+        generateCorrectedAssertion(versionOfRecord, new Date('2024-06-09')),
+      ],
+    ));
+    addNextStep(nextStep, generateStep(
+      [{
+        ...versionOfRecord,
+        identifier: versionOfRecordOutput.identifier,
+      }],
+      [
+        generateAction([], [
+          {
+            ...versionOfRecord,
+            content: [
+              generateWebContent('https://doi.org/version-of-record-corrected-again')
+            ],
+          },
+        ]),
+      ],
+      [
+        generateCorrectedAssertion(versionOfRecord, new Date('2024-06-10')),
+      ],
+    ));
 
     return generateDocMap('test', publisher, firstStep);
   },

--- a/src/test-fixtures/docmap-parser.ts
+++ b/src/test-fixtures/docmap-parser.ts
@@ -19,7 +19,9 @@ import {
   generateUnderReviewAssertion,
   generateWebContent,
   generateManuscript,
-  generateInsight, generateVersionOfRecord, generateCorrectedAssertion,
+  generateInsight,
+  generateVersionOfRecord,
+  generateCorrectedAssertion,
 } from '../generators/docmap-generators';
 
 const publisher = {

--- a/src/types/docmap.ts
+++ b/src/types/docmap.ts
@@ -49,6 +49,7 @@ export enum AssertionStatus {
   VersionOfRecord = 'version-of-record',
   Revised = 'revised',
   Republished = 'republished',
+  Corrected = 'corrected',
 }
 
 export type Assertion = {


### PR DESCRIPTION
Implemented parsing and generation of corrected assertions in docmap. Tests and fixtures were updated to verify this new feature. An additional correctedDate field was added to preprints and reviewed preprints. A new corrected status was also added to AssertionStatus.